### PR TITLE
Add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
     "prepublish": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore __tests__"
   },
-  "keywords": [],
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "markdown",
+    "mdx",
+    "jsx"
+  ],
   "author": "",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
The `gatsby` and `gatsby-plugin` keywords will add this package to [Gatsby's Plugin Library](https://www.gatsbyjs.org/plugins/).