### PR TITLE
Update to new Gatsby Webpack APIs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,8 @@
-export function resolvableExtensions() {
+exports.resolvableExtensions = function () {
   return [`.md`];
-}
+};
 
-export function onCreateWebpackConfig({ actions }) {
+exports.onCreateWebpackConfig = function ({ actions }) {
   const mdFiles = /\.mdx?$/;
   actions.setWebpackConfig({
     module: {
@@ -12,4 +12,4 @@ export function onCreateWebpackConfig({ actions }) {
       }]
     }
   });
-}
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,17 +1,15 @@
-// const webpack = require(`webpack`)
+export function resolvableExtensions() {
+  return [`.md`];
+}
 
-// Add Glamor support
-exports.modifyWebpackConfig = ({ config, stage }) => {
+export function onCreateWebpackConfig({ actions }) {
   const mdFiles = /\.mdx?$/;
-  config.loader(`mdx`, {
-    test: mdFiles,
-    loaders: ['babel-loader?' + 'babelrc=false,' + 'presets[]=env,' + 'presets[]=react', '@mdx-js/loader']
+  actions.setWebpackConfig({
+    module: {
+      rules: [{
+        test: mdFiles,
+        use: ['babel-loader?' + 'babelrc=false,' + 'presets[]=env,' + 'presets[]=react', '@mdx-js/loader']
+      }]
+    }
   });
-};
-
-// Add Glamor support
-// exports.modifyBabelrc = ({ babelrc }) => {
-//   return Object.assign(babelrc, {
-//     plugins: babelrc.plugins.concat(['@mdx-js/loader']),
-//   })
-// }
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,7 +2,7 @@ export function resolvableExtensions() {
   return [`.md`]
 }
 
-export function onCreateWebpackConfig = ({ actions }) => {
+export function onCreateWebpackConfig({ actions }) {
   const mdFiles = /\.mdx?$/
   actions.setWebpackConfig({
     module: {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,20 +1,20 @@
-// const webpack = require(`webpack`)
-
-// Add Glamor support
-exports.modifyWebpackConfig = ({ config, stage }) => {
-  const mdFiles = /\.mdx?$/
-  config.loader(`mdx`, {
-    test: mdFiles,
-    loaders: [
-      'babel-loader?' + 'babelrc=false,' + 'presets[]=env,' + 'presets[]=react',
-      '@mdx-js/loader',
-    ],
-  })
+export function resolvableExtensions() {
+  return [`.md`]
 }
 
-// Add Glamor support
-// exports.modifyBabelrc = ({ babelrc }) => {
-//   return Object.assign(babelrc, {
-//     plugins: babelrc.plugins.concat(['@mdx-js/loader']),
-//   })
-// }
+export function onCreateWebpackConfig = ({ actions }) => {
+  const mdFiles = /\.mdx?$/
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: mdFiles,
+          use: [
+            'babel-loader?' + 'babelrc=false,' + 'presets[]=env,' + 'presets[]=react',
+            '@mdx-js/loader',
+          ],
+        },
+      ],
+    },
+  })
+}

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,8 +1,8 @@
-export function resolvableExtensions() {
+exports.resolvableExtensions = function() {
   return [`.md`]
 }
 
-export function onCreateWebpackConfig({ actions }) {
+exports.onCreateWebpackConfig = function({ actions }) {
   const mdFiles = /\.mdx?$/
   actions.setWebpackConfig({
     module: {


### PR DESCRIPTION
`modifyWebpackConfig` is going away in V2 of Gatsby. This PR updates the plugin to support the newer `onCreateWebpackConfig` API.

## Test Plan

- [x] Confirm `gatsby develop` and `gatsby build` in the `examples/basic` directory runs with no errors